### PR TITLE
Updated Changes file to be conformant with CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -120,7 +120,7 @@ Revision history for Dist-Zilla-PluginBundle-RSRCHBOY
 	* add initial Pod::Weaver config bundle
 	* allow a local weaver.ini to override our config
 
-0.012
+0.012     2012-01-10 America/Los_Angeles
 	* change "cat_app" option to just "app"; preserve cat_app for legacy
 	* dist.ini tweaks
 


### PR DESCRIPTION
Hi,

I added the date for the 0.012 release -- not having the date was causing it to fail against testing for CPAN::Changes::Spec. I got the date from backpan.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's CPAN::Changes Kwalitee Service (http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil
